### PR TITLE
Fix error in MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ batch-nearby-search = "batch_nearby_search.server:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/batch_nearby_search"]
+
 [tool.black]
 line-length = 100
 target-version = ['py310']


### PR DESCRIPTION
Added tool.hatch.build.targets.wheel configuration to tell Hatchling where to find the batch_nearby_search package in the src/ directory. This resolves the "Unable to determine which files to ship" error.