### PR TITLE
Add geo-coding tool to MCP server

### DIFF
--- a/src/batch_nearby_search/cache.py
+++ b/src/batch_nearby_search/cache.py
@@ -114,6 +114,45 @@ def set_places_cache(lat: float, lng: float, feature_type: str, radius: int, pla
     places_cache[key] = places
 
 
+def get_reverse_geocoding_cache(lat: float, lng: float) -> dict | None:
+    """
+    Get reverse geocoding result from cache.
+
+    Args:
+        lat: Latitude
+        lng: Longitude
+
+    Returns:
+        Cached address dict or None if not cached
+    """
+    # Round coordinates to reduce cache misses from tiny differences
+    lat_rounded = round(lat, 4)  # ~11 meters precision
+    lng_rounded = round(lng, 4)
+    key = make_cache_key("reverse_geocode", lat_rounded, lng_rounded)
+
+    result = geocoding_cache.get(key)
+    if result:
+        cache_stats["geocoding_hits"] += 1
+    else:
+        cache_stats["geocoding_misses"] += 1
+    return result
+
+
+def set_reverse_geocoding_cache(lat: float, lng: float, address_data: dict) -> None:
+    """
+    Store reverse geocoding result in cache.
+
+    Args:
+        lat: Latitude
+        lng: Longitude
+        address_data: Dict with address information
+    """
+    lat_rounded = round(lat, 4)
+    lng_rounded = round(lng, 4)
+    key = make_cache_key("reverse_geocode", lat_rounded, lng_rounded)
+    geocoding_cache[key] = address_data
+
+
 def get_cache_stats() -> dict:
     """
     Get cache statistics.

--- a/src/batch_nearby_search/models.py
+++ b/src/batch_nearby_search/models.py
@@ -59,6 +59,31 @@ class PlaceResult(BaseModel):
         extra = "allow"  # Allow additional fields from Google API if needed
 
 
+class GeocodeResult(BaseModel):
+    """Result from geocoding an address to coordinates"""
+
+    address: str = Field(..., description="Original address queried")
+    formatted_address: str = Field(..., description="Formatted address from Google")
+    lat: float = Field(..., description="Latitude")
+    lng: float = Field(..., description="Longitude")
+    place_id: str | None = Field(None, description="Google Place ID")
+    address_components: list[dict] | None = Field(
+        None, description="Detailed address components (street, city, state, etc.)"
+    )
+
+
+class ReverseGeocodeResult(BaseModel):
+    """Result from reverse geocoding coordinates to address"""
+
+    lat: float = Field(..., description="Latitude queried")
+    lng: float = Field(..., description="Longitude queried")
+    formatted_address: str = Field(..., description="Formatted address from Google")
+    place_id: str | None = Field(None, description="Google Place ID")
+    address_components: list[dict] | None = Field(
+        None, description="Detailed address components (street, city, state, etc.)"
+    )
+
+
 class DistanceMatrixResult(BaseModel):
     """Result for a single origin-destination pair in distance matrix"""
 

--- a/src/batch_nearby_search/utils.py
+++ b/src/batch_nearby_search/utils.py
@@ -288,3 +288,71 @@ def format_distance_matrix_results(results: list[dict], summary: dict) -> str:
             lines.append(f"- {origin} -> {destination} ERROR: {status}")
 
     return "\n".join(lines) if lines else "No routes found"
+
+
+def format_geocode_results(results: list[dict], summary: dict) -> str:
+    """
+    Format geocoding results in log-style output.
+
+    Each line shows: address -> (lat, lng)
+
+    Args:
+        results: List of geocoding results
+        summary: Summary statistics
+
+    Returns:
+        Log-style output with each geocoded address on a separate line
+    """
+    lines = []
+
+    for result in results:
+        address = result.get("address", "Unknown")
+        status = result.get("status", "success")
+
+        if status == "success":
+            formatted_address = result.get("formatted_address", "")
+            lat = result.get("lat")
+            lng = result.get("lng")
+
+            # Format: - "Original Address" -> "Formatted Address" (lat, lng)
+            if formatted_address and lat is not None and lng is not None:
+                lines.append(f'- "{address}" -> "{formatted_address}" ({lat:.4f}, {lng:.4f})')
+            else:
+                lines.append(f'- "{address}" ERROR: Missing coordinates')
+        else:
+            error = result.get("error", "Unknown error")
+            lines.append(f'- "{address}" ERROR: {error}')
+
+    return "\n".join(lines) if lines else "No addresses geocoded"
+
+
+def format_reverse_geocode_results(results: list[dict], summary: dict) -> str:
+    """
+    Format reverse geocoding results in log-style output.
+
+    Each line shows: (lat, lng) -> address
+
+    Args:
+        results: List of reverse geocoding results
+        summary: Summary statistics
+
+    Returns:
+        Log-style output with each reverse geocoded location on a separate line
+    """
+    lines = []
+
+    for result in results:
+        lat = result.get("lat")
+        lng = result.get("lng")
+        status = result.get("status", "success")
+
+        coord_str = f"({lat:.4f}, {lng:.4f})" if lat is not None and lng is not None else "(?, ?)"
+
+        if status == "success":
+            formatted_address = result.get("formatted_address", "Unknown")
+            lines.append(f'- {coord_str} -> "{formatted_address}"')
+        else:
+            error = result.get("error", "Unknown error")
+            lines.append(f"- {coord_str} ERROR: {error}")
+
+    return "\n".join(lines) if lines else "No locations reverse geocoded"

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -1,0 +1,151 @@
+"""
+Tests for geocoding functionality
+"""
+
+import pytest
+import asyncio
+from unittest.mock import Mock, AsyncMock, patch
+from src.batch_nearby_search.google_client import GooglePlacesClient
+from src.batch_nearby_search.cache import (
+    get_geocoding_cache,
+    set_geocoding_cache,
+    get_reverse_geocoding_cache,
+    set_reverse_geocoding_cache,
+    clear_caches,
+)
+
+
+@pytest.fixture
+def mock_google_client():
+    """Create a mock Google client for testing"""
+    with patch.dict('os.environ', {'GOOGLE_MAPS_API_KEY': 'test_key'}):
+        client = GooglePlacesClient(api_key='test_key', max_concurrent=5)
+        yield client
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_before_test():
+    """Clear caches before each test"""
+    clear_caches()
+    yield
+    clear_caches()
+
+
+def test_geocoding_cache():
+    """Test geocoding cache functionality"""
+    address = "1600 Amphitheatre Parkway, Mountain View, CA"
+    coords = {"lat": 37.4220, "lng": -122.0841, "formatted_address": "Test Address"}
+
+    # Should be None initially
+    assert get_geocoding_cache(address) is None
+
+    # Set cache
+    set_geocoding_cache(address, coords)
+
+    # Should retrieve from cache
+    cached = get_geocoding_cache(address)
+    assert cached is not None
+    assert cached["lat"] == 37.4220
+    assert cached["lng"] == -122.0841
+
+
+def test_reverse_geocoding_cache():
+    """Test reverse geocoding cache functionality"""
+    lat = 37.4220
+    lng = -122.0841
+    address_data = {
+        "lat": lat,
+        "lng": lng,
+        "formatted_address": "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
+        "place_id": "test_place_id",
+    }
+
+    # Should be None initially
+    assert get_reverse_geocoding_cache(lat, lng) is None
+
+    # Set cache
+    set_reverse_geocoding_cache(lat, lng, address_data)
+
+    # Should retrieve from cache
+    cached = get_reverse_geocoding_cache(lat, lng)
+    assert cached is not None
+    assert cached["formatted_address"] == address_data["formatted_address"]
+    assert cached["lat"] == lat
+    assert cached["lng"] == lng
+
+
+def test_reverse_geocoding_cache_rounding():
+    """Test that reverse geocoding cache rounds coordinates properly"""
+    # These coordinates should round to the same cache key
+    lat1, lng1 = 37.42201, -122.08411
+    lat2, lng2 = 37.42204, -122.08414
+
+    address_data = {
+        "lat": lat1,
+        "lng": lng1,
+        "formatted_address": "Test Address",
+    }
+
+    # Set cache with first coordinates
+    set_reverse_geocoding_cache(lat1, lng1, address_data)
+
+    # Should retrieve with slightly different coordinates (within rounding)
+    cached = get_reverse_geocoding_cache(lat2, lng2)
+    assert cached is not None
+    assert cached["formatted_address"] == "Test Address"
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_location_with_mock():
+    """Test reverse_geocode_location method with mocked Google API"""
+    with patch.dict('os.environ', {'GOOGLE_MAPS_API_KEY': 'test_key'}):
+        client = GooglePlacesClient(api_key='test_key', max_concurrent=5)
+
+        # Mock the reverse_geocode API call
+        mock_result = [{
+            "formatted_address": "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
+            "place_id": "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
+            "address_components": [
+                {"long_name": "1600", "short_name": "1600", "types": ["street_number"]},
+                {"long_name": "Amphitheatre Parkway", "short_name": "Amphitheatre Pkwy", "types": ["route"]},
+            ],
+        }]
+
+        with patch.object(client.client, 'reverse_geocode', return_value=mock_result):
+            result = await client.reverse_geocode_location(37.4220, -122.0841)
+
+            assert result is not None
+            assert result["lat"] == 37.4220
+            assert result["lng"] == -122.0841
+            assert result["formatted_address"] == "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA"
+            assert result["place_id"] == "ChIJ2eUgeAK6j4ARbn5u_wAGqWA"
+            assert len(result["address_components"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_location_caching():
+    """Test that reverse geocoding results are cached"""
+    with patch.dict('os.environ', {'GOOGLE_MAPS_API_KEY': 'test_key'}):
+        client = GooglePlacesClient(api_key='test_key', max_concurrent=5)
+
+        mock_result = [{
+            "formatted_address": "Test Address",
+            "place_id": "test_place_id",
+            "address_components": [],
+        }]
+
+        with patch.object(client.client, 'reverse_geocode', return_value=mock_result) as mock_reverse_geocode:
+            # First call should hit the API
+            result1 = await client.reverse_geocode_location(37.4220, -122.0841)
+            assert mock_reverse_geocode.call_count == 1
+
+            # Second call should use cache
+            result2 = await client.reverse_geocode_location(37.4220, -122.0841)
+            assert mock_reverse_geocode.call_count == 1  # Still 1, not 2
+
+            # Results should be the same
+            assert result1["formatted_address"] == result2["formatted_address"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements two new MCP tools following existing patterns:
- geocode: Convert addresses to coordinates (forward geocoding)
- reverse_geocode: Convert coordinates to addresses (reverse geocoding)

Key features:
- Batch support for multiple addresses/coordinates in parallel
- Caching to reduce API costs (geocoding cache reused)
- Format parameter for text (default) or JSON output
- Comprehensive error handling with partial results
- Consistent log-style output matching other tools
- Pydantic models for validation

Implementation details:
- Added GeocodeResult and ReverseGeocodeResult models
- Added reverse_geocode_location() method to GooglePlacesClient
- Added reverse geocoding cache functions to cache.py
- Added formatting functions for geocode results
- Updated server.py with @mcp.tool decorated functions
- Includes test file for validation

All changes follow existing codebase patterns and integrate seamlessly with the current MCP server architecture.